### PR TITLE
Use --update instead of --no-clobber

### DIFF
--- a/hubploy/imagebuilder.py
+++ b/hubploy/imagebuilder.py
@@ -53,7 +53,7 @@ def build_image(client, path, image_spec, cache_from=None, build_progress_cb=Non
 def build_repo2docker(client, path, image_spec):
     ENTRYPOINT = '''\
 #!/bin/bash
-cp --archive --recursive --no-clobber /srv/home/ -T ${HOME}
+cp --archive --recursive --update /srv/home/ -T ${HOME}
 if [ -x binder/start ]; then
   exec binder/start "$@"
 else


### PR DESCRIPTION
Configuration files and examples need to be re-copied if they're changed, instead of using whatever is in the persisted user home directory.